### PR TITLE
Error handling for when error instance is raised

### DIFF
--- a/pytest_excel/pytest_excel.py
+++ b/pytest_excel/pytest_excel.py
@@ -75,7 +75,10 @@ class ExcelReporter(object):
     def update_worksheet(self):
         for data in self.results:
             for key, value in data.items():
-                self.wsheet.cell(row=self.rc, column=list(data).index(key) + 1).value = value
+                try:
+                    self.wsheet.cell(row=self.rc, column=list(data).index(key) + 1).value = value
+                except ValueError:
+                    self.wsheet.cell(row=self.rc, column=list(data).index(key) + 1).value = str(vars(value))
             self.rc = self.rc + 1
 
 


### PR DESCRIPTION
Fix for #18 

Might be good idea to display the details of the error instance on the excel instead of not having an excel output, which ignores/hides the actual error with this ValueError.