### PR TITLE
Update pytest_excel.py

### DIFF
--- a/pytest_excel/pytest_excel.py
+++ b/pytest_excel/pytest_excel.py
@@ -243,5 +243,6 @@ class ExcelReporter(object):
 
 
     def pytest_terminal_summary(self, terminalreporter):
-        terminalreporter.write_sep("-", "excel report: %s" % (self.excelpath))
+        if self.results:
+            terminalreporter.write_sep("-", "excel report: %s" % (self.excelpath))
 


### PR DESCRIPTION
Check the results variable before printing to the terminal so that it does not print a message with the name of the nonexistent report. Fixes #25.