### PR TITLE
add a new column named "full_test_name"

### DIFF
--- a/pytest_excel/pytest_excel.py
+++ b/pytest_excel/pytest_excel.py
@@ -88,6 +88,7 @@ class ExcelReporter(object):
         result['timestamp'] = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
         result['message']   = message
         result['file_name'] = report.location[0]
+        result['full_test_name'] = report.nodeid
         result['markers']   = report.test_marker
         self.append(result)
 


### PR DESCRIPTION
The current `file_name` is the actual location of a test item, as can be seem from [here](https://github.com/pytest-dev/pytest/blob/9d7bf4e544f6e9d43ab0dd390a820d4dae140a53/src/_pytest/reports.py#L295).

However, this causes a problem when I have 2 test items from 2 test files with the same name that inherit from the same test module, e.g. When I run the following command: 

```bash
pytest -rA tests -k "GemmaModelTest and test_eager_matches_sdpa_inference" --excelreport test_pytest.xlsx
```
I see:
![image](https://github.com/user-attachments/assets/a9bcdcc1-6273-4390-a938-8f7381c5c19d)

In this case, the information of the actual test file name is missing in the test report. So I can't distinguish which case is from which test file. This PR fixes this issue. 

There are several ways to fix it, but I found adding column is the best, because 
1. I won't change the old behavior
2. if users want to rerun the test, it would be convenient to just copy the entire block instead of copying 3 blocks. 

Below is the result after this PR: 
![image](https://github.com/user-attachments/assets/ab1ba1f5-1148-41ca-9a25-c1270963dc1f)


